### PR TITLE
Refactor HTTP server and handle OS signals 

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,13 @@ import (
 )
 
 var (
-	runAsDaemon bool
+	runAsDaemon   bool
+	daemonContext daemon.Context
 )
 
 func init() {
+	SetupInterruptHandler()
+
 	rootCmd.PersistentFlags().BoolVarP(&runAsDaemon, "daemon", "D", false, "run Go WebSockify as daemon")
 }
 
@@ -23,8 +26,7 @@ func main() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 }
 
@@ -32,13 +34,15 @@ var rootCmd = &cobra.Command{
 	Use:  "go-websockify",
 	Long: `Starts a WebSocket server which facilitates a bidirectional communications channel. Endpoints are responsible for implementing their own transport layer, Go WebSockify's only job is to move buffers from point A to B.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Println("Starting Go WebSockify")
+
 		if runAsDaemon {
-			cntxt := &daemon.Context{
+			daemonContext := &daemon.Context{
 				PidFileName: "go-websockify.pid",
 				PidFilePerm: 0644,
 			}
 
-			daemon, err := cntxt.Reborn()
+			daemon, err := daemonContext.Reborn()
 			if err != nil {
 				log.Fatalf("Unable to start %s", err.Error())
 				return
@@ -46,13 +50,10 @@ var rootCmd = &cobra.Command{
 			if daemon != nil {
 				return
 			}
-			defer cntxt.Release()
+			defer daemonContext.Release()
 
-			log.Println("Starting server listening on port 127.0.0.1:8080")
-			daemonMessage := fmt.Sprintf("Running daemon under PID %d", os.Getpid())
+			daemonMessage := fmt.Sprintf("Running Go WebSockify daemon under PID %d", os.Getpid())
 			log.Println(daemonMessage)
-		} else {
-			log.Println("Starting server listening on port 127.0.0.1:8080")
 		}
 		StartHTTP()
 	},

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+)
+
+var (
+	signals = make(chan os.Signal, 1)
+)
+
+func SetupInterruptHandler() {
+	signal.Notify(signals, os.Interrupt)
+
+	go func() {
+		<-signals
+		log.Println("Shutting down Go WebSockify")
+		if err := server.Shutdown(ctx); err != nil {
+			log.Fatalln(err)
+		} else {
+			os.Exit(0)
+		}
+	}()
+}


### PR DESCRIPTION
This PR refactors the web server into its own module.

- Add support for graceful HTTP shutdowns by intercepting signal `SIGINT`
- Remove WebSocket compression default.