### PR TITLE
Empty proxyServer struct on WebSocket read error

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -85,7 +85,7 @@ func (proxyServer *ProxyServer) webSocketToTCP() {
 		if err != nil {
 			proxyServer.wsConn.Close()
 			proxyServer.tcpConn.Close()
-			proxyServer = &ProxyServer{}
+			proxyServer = nil
 			break
 		}
 


### PR DESCRIPTION
Make `proxyServer` nil if there's an error while reading the WebSocket connection buffer