### PR TITLE
Added HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Go WebSockify exports the following Prometheus metrics at `/metrics`:
 - go_websockify_tcp_connections_active
 
 ## Roadmap
-- [ ] Support TLS on WebSocket connections.
+- [X] Support TLS on WebSocket connections.
 - [ ] Support authenticating WebSocket connections through a plugin system (https://github.com/traefik/yaegi).
 - [ ] Support for proxying UNIX sockets to WebSockets.
 - [ ] Support backend TCP connection reuse.

--- a/main.go
+++ b/main.go
@@ -17,6 +17,11 @@ var config struct {
 	bufferSize int
 	httpPath   string
 
+	// ssl support
+
+	cert string
+	key  string
+
 	runAsDaemon bool
 	showVersion bool
 	echoServer  bool
@@ -34,6 +39,9 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&config.bufferSize, "buffer", 65536, "buffer size")
 	rootCmd.PersistentFlags().BoolVar(&config.echoServer, "echo", false, "sidecar echo server")
 	rootCmd.PersistentFlags().StringVar(&config.httpPath, "path", "/websockify", "url path clients connect to")
+
+	rootCmd.PersistentFlags().StringVar(&config.cert, "cert", "", "SSL certificate file")
+	rootCmd.PersistentFlags().StringVar(&config.key, "key", "", "SSL key file")
 
 	rootCmd.Flags().BoolVarP(&config.runAsDaemon, "daemon", "D", false, "run as daemon")
 	rootCmd.Flags().BoolVarP(&config.showVersion, "version", "v", false, "print version")


### PR DESCRIPTION
This implements two new arguments: `cert` and `key`

if they're provided, proxy starts in TLS mode and supports WSS connections.